### PR TITLE
Add comprehensive unit tests for Chip Heater backend

### DIFF
--- a/backend/src/heater/api/webhooks.py
+++ b/backend/src/heater/api/webhooks.py
@@ -26,7 +26,11 @@ async def update_instance_status(instance_name: str, status: str):
 
 @router.post("/evolution")
 async def evolution_webhook(request: Request, background_tasks: BackgroundTasks):
-    data = await request.json()
+    try:
+        data = await request.json()
+    except Exception:
+        return {"status": "error", "reason": "invalid_json"}
+
     # print(f"Received webhook: {data}")
 
     # Evolution API 2.0+ structure varies.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,100 @@
+import os
+# Set environment variables for testing before importing app
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
+os.environ["EVOLUTION_URL"] = "http://mock-evolution"
+os.environ["EVOLUTION_API_KEY"] = "mock-key"
+os.environ["JWT_SECRET"] = "testsecret"
+os.environ["REDIS_URL"] = "redis://mock"
+
+import pytest
+import pytest_asyncio
+import asyncio
+from typing import AsyncGenerator
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Now import app modules
+from heater.main import app
+from heater.database import Base, get_db
+from heater.dependencies import get_evolution
+from heater.config import settings
+
+@pytest_asyncio.fixture(scope="session")
+def event_loop():
+    """Create an instance of the default event loop for each test case."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest_asyncio.fixture(scope="function")
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    # Use in-memory SQLite
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # Patch AsyncSessionLocal where it is used directly (e.g. background tasks)
+    # We need to target the module where it is imported.
+    # We patch it to return a session from OUR engine.
+    # Note: side_effect=SessionLocal makes the mock call SessionLocal() when called.
+
+    # We need to ensure modules are loaded so patch works on them
+    # heater.api.webhooks is imported by heater.main
+
+    with patch("heater.api.webhooks.AsyncSessionLocal", side_effect=SessionLocal), \
+         patch("heater.scheduler.AsyncSessionLocal", side_effect=SessionLocal):
+
+        async with SessionLocal() as session:
+            yield session
+
+    await engine.dispose()
+
+@pytest.fixture(scope="function")
+def mock_evolution():
+    client = MagicMock()
+    # Async methods need to be AsyncMock
+    client.create_instance = AsyncMock(return_value={"instance": {"key": "test"}})
+    client.get_qrcode = AsyncMock(return_value="base64qrcode")
+    client.send_text = AsyncMock(return_value={"key": {"id": "MSG_ID_123"}})
+    client.send_reaction = AsyncMock(return_value={"status": "ok"})
+    client.set_presence = AsyncMock(return_value={"status": "ok"})
+    return client
+
+@pytest_asyncio.fixture(scope="function")
+async def client(db_session, mock_evolution) -> AsyncGenerator[AsyncClient, None]:
+    # Override dependencies
+    async def override_get_db():
+        yield db_session
+
+    def override_get_evolution():
+        return mock_evolution
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_evolution] = override_get_evolution
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+@pytest.fixture
+def auth_headers():
+    from heater.api.auth import create_access_token
+    token = create_access_token(data={"sub": "test@example.com"})
+    return {"Authorization": f"Bearer {token}"}
+
+@pytest_asyncio.fixture
+async def create_user(db_session):
+    from heater.models.user import User
+    from heater.api.auth import get_password_hash
+    user = User(email="test@example.com", hashed_password=get_password_hash("password"))
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user

--- a/backend/tests/test_api_instances.py
+++ b/backend/tests/test_api_instances.py
@@ -1,0 +1,58 @@
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_create_instance(client: AsyncClient, create_user, auth_headers, mock_evolution):
+    response = await client.post("/instances/", json={"name": "test_instance"}, headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "test_instance"
+    assert "id" in data
+    mock_evolution.create_instance.assert_called_once_with("test_instance")
+
+@pytest.mark.asyncio
+async def test_list_instances(client: AsyncClient, create_user, auth_headers):
+    # Create first
+    await client.post("/instances/", json={"name": "inst1"}, headers=auth_headers)
+    await client.post("/instances/", json={"name": "inst2"}, headers=auth_headers)
+
+    response = await client.get("/instances/", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    # Note: DB is fresh per function, but if creating multiple instances, ensure order or check existence
+    assert len(data) == 2
+    names = [inst["name"] for inst in data]
+    assert "inst1" in names
+    assert "inst2" in names
+
+@pytest.mark.asyncio
+async def test_get_qrcode(client: AsyncClient, create_user, auth_headers, mock_evolution):
+    # Create instance
+    create_resp = await client.post("/instances/", json={"name": "qr_instance"}, headers=auth_headers)
+    instance_id = create_resp.json()["id"]
+
+    response = await client.get(f"/instances/{instance_id}/qrcode", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["qrcode"] == "base64qrcode"
+    mock_evolution.get_qrcode.assert_called_once_with("qr_instance")
+
+@pytest.mark.asyncio
+async def test_start_warming(client: AsyncClient, create_user, auth_headers):
+    # Create instance
+    create_resp = await client.post("/instances/", json={"name": "warm_instance"}, headers=auth_headers)
+    instance_id = create_resp.json()["id"]
+
+    # Start warming
+    response = await client.post(f"/instances/{instance_id}/warming/start", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["status"] == "warming started"
+
+    # Stop warming
+    stop_resp = await client.post(f"/instances/{instance_id}/warming/stop", headers=auth_headers)
+    assert stop_resp.status_code == 200
+    assert stop_resp.json()["status"] == "warming stopped"
+
+@pytest.mark.asyncio
+async def test_instance_not_found(client: AsyncClient, create_user, auth_headers):
+    response = await client.get("/instances/999/qrcode", headers=auth_headers)
+    assert response.status_code == 404

--- a/backend/tests/test_api_webhooks.py
+++ b/backend/tests/test_api_webhooks.py
@@ -1,0 +1,69 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from heater.models.instance import Instance
+from heater.models.user import User
+import asyncio
+
+@pytest.mark.asyncio
+async def test_webhook_connection_update_connected(client: AsyncClient, db_session, create_user):
+    # Ensure user exists (create_user fixture creates one, likely id=1)
+    user = create_user # This returns the user object
+
+    # Create instance in DB
+    inst = Instance(name="hook_inst", status="disconnected", user_id=user.id)
+    db_session.add(inst)
+    await db_session.commit()
+
+    payload = {
+        "event": "connection.update",
+        "instance": "hook_inst",
+        "data": {
+            "state": "open"
+        }
+    }
+
+    response = await client.post("/webhooks/evolution", json=payload)
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+    # Wait for background task execution
+    await asyncio.sleep(0.1)
+
+    await db_session.refresh(inst)
+    assert inst.status == "connected"
+
+@pytest.mark.asyncio
+async def test_webhook_connection_update_disconnected(client: AsyncClient, db_session, create_user):
+    user = create_user
+    inst = Instance(name="hook_inst_2", status="connected", user_id=user.id)
+    db_session.add(inst)
+    await db_session.commit()
+
+    payload = {
+        "event": "connection.update",
+        "instance": "hook_inst_2",
+        "data": {
+            "state": "close"
+        }
+    }
+
+    response = await client.post("/webhooks/evolution", json=payload)
+    assert response.status_code == 200
+
+    await asyncio.sleep(0.1)
+
+    await db_session.refresh(inst)
+    assert inst.status == "disconnected"
+
+@pytest.mark.asyncio
+async def test_webhook_unknown_instance(client: AsyncClient):
+    payload = {
+        "event": "connection.update",
+        "instance": "unknown_inst",
+        "data": {
+            "state": "open"
+        }
+    }
+    response = await client.post("/webhooks/evolution", json=payload)
+    assert response.status_code == 200

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,44 @@
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_register_user(client: AsyncClient, db_session):
+    payload = {"email": "newuser@example.com", "password": "password123"}
+    response = await client.post("/auth/register", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "newuser@example.com"
+    assert "id" in data
+
+@pytest.mark.asyncio
+async def test_register_existing_user(client: AsyncClient, create_user):
+    payload = {"email": "test@example.com", "password": "password123"}
+    response = await client.post("/auth/register", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Email already registered"
+
+@pytest.mark.asyncio
+async def test_login_success(client: AsyncClient, create_user):
+    # create_user uses "password" as password (defined in conftest.py)
+    payload = {"username": "test@example.com", "password": "password"}
+    response = await client.post("/auth/token", data=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+@pytest.mark.asyncio
+async def test_login_wrong_password(client: AsyncClient, create_user):
+    payload = {"username": "test@example.com", "password": "wrongpassword"}
+    response = await client.post("/auth/token", data=payload)
+    assert response.status_code == 401
+
+@pytest.mark.asyncio
+async def test_protected_route_access(client: AsyncClient, create_user, auth_headers):
+    # Without token
+    response = await client.get("/instances/")
+    assert response.status_code == 401
+
+    # With token
+    response = await client.get("/instances/", headers=auth_headers)
+    assert response.status_code == 200

--- a/backend/tests/test_error_handling.py
+++ b/backend/tests/test_error_handling.py
@@ -1,0 +1,70 @@
+import pytest
+from httpx import AsyncClient
+from unittest.mock import AsyncMock, patch
+
+@pytest.mark.asyncio
+async def test_evolution_api_create_error(client: AsyncClient, create_user, auth_headers, mock_evolution):
+    # Mock create_instance failure
+    mock_evolution.create_instance.side_effect = Exception("API connection failed")
+
+    # The current implementation in api/instances.py catches exception
+    response = await client.post("/instances/", json={"name": "failed_api"}, headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "failed_api"
+    # It should still be created in DB
+
+@pytest.mark.asyncio
+async def test_engine_send_message_error(db_session, mock_evolution):
+    # Setup
+    from heater.models.instance import Instance
+    from heater.warming.engine import WarmingEngine
+    from heater.models.message import Message
+    from sqlalchemy import select
+
+    from heater.models.user import User
+    user = User(email="e@e.com", hashed_password="pw")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    me = Instance(name="me_err", phone_number="111111", user_id=user.id, status="connected")
+    peer = Instance(name="peer_err", phone_number="222222", user_id=user.id, status="connected")
+    db_session.add_all([me, peer])
+    await db_session.commit()
+
+    mock_evolution.send_text.side_effect = Exception("Evolution failure")
+
+    engine = WarmingEngine(mock_evolution, db_session)
+
+    # Mock ContentGenerator and HumanBehavior to avoid delays and randomness
+    with patch("heater.warming.engine.ContentGenerator.casual_message", return_value="Hello"), \
+         patch("heater.warming.engine.HumanBehavior.typing_delay", new_callable=AsyncMock) as mock_delay:
+        mock_delay.return_value = 0.0
+
+        # Run send_private_message directly
+        await engine.send_private_message(me, peer)
+
+    # Should handle exception and not crash
+    # Should not log success message in DB
+    result = await db_session.execute(select(Message).where(Message.instance_id == me.id))
+    messages = result.scalars().all()
+    assert len(messages) == 0
+
+@pytest.mark.asyncio
+async def test_auth_invalid_token(client: AsyncClient):
+    response = await client.get("/instances/", headers={"Authorization": "Bearer invalid"})
+    assert response.status_code == 401
+
+@pytest.mark.asyncio
+async def test_malformed_webhook(client: AsyncClient):
+    # Send weird JSON
+    response = await client.post("/webhooks/evolution", content="not json", headers={"Content-Type": "application/json"})
+    # We updated the endpoint to return 200 with error status
+    assert response.status_code == 200
+    assert response.json()["status"] == "error"
+
+    # Send valid JSON but missing fields
+    response = await client.post("/webhooks/evolution", json={"foo": "bar"})
+    # Implementation handles missing fields gracefully (doesn't crash)
+    assert response.status_code == 200

--- a/backend/tests/test_warming_engine.py
+++ b/backend/tests/test_warming_engine.py
@@ -1,0 +1,166 @@
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, AsyncMock, patch
+from heater.warming.engine import WarmingEngine
+from heater.models.instance import Instance
+from heater.models.message import Message
+from sqlalchemy import select
+
+@pytest.fixture
+def engine_instance(db_session, mock_evolution):
+    return WarmingEngine(evolution=mock_evolution, db=db_session)
+
+@pytest.mark.asyncio
+async def test_select_peer_logic(engine_instance, db_session):
+    # Setup instances
+    # Need user first because of FK? If SQLite FKs are enforced (they are not by default in SQLAlchemy unless configured)
+    # But create_async_engine might not enforce them or user_id=1 might be fine if table empty
+    # Best practice is to create user.
+    from heater.models.user import User
+    user = User(email="t@t.com", hashed_password="pw")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    me = Instance(name="me", phone_number="111111", user_id=user.id, status="connected")
+    p1 = Instance(name="p1", phone_number="222222", user_id=user.id, status="connected") # Old interaction
+    p2 = Instance(name="p2", phone_number="333333", user_id=user.id, status="connected") # Recent interaction
+    db_session.add_all([me, p1, p2])
+    await db_session.commit()
+
+    # Log interactions
+    # p2 talked recently
+    msg2 = Message(instance_id=me.id, peer_number=p2.phone_number, created_at=datetime.utcnow() - timedelta(minutes=1))
+    # p1 talked long ago
+    msg1 = Message(instance_id=me.id, peer_number=p1.phone_number, created_at=datetime.utcnow() - timedelta(days=1))
+
+    db_session.add_all([msg1, msg2])
+    await db_session.commit()
+
+    # Test selection distribution
+    counts = {"p1": 0, "p2": 0}
+    peers = [p1, p2]
+
+    # Run multiple times to verify weighted random
+    for _ in range(100):
+        selected = await engine_instance._select_peer(me, peers)
+        if selected.id == p1.id:
+            counts["p1"] += 1
+        else:
+            counts["p2"] += 1
+
+    # p1 should be selected significantly more because weight = delta (time since last msg)
+    # p1 delta ~ 86400s
+    # p2 delta ~ 60s
+    assert counts["p1"] > counts["p2"]
+    assert counts["p1"] > 80 # Should be very high
+
+@pytest.mark.asyncio
+async def test_run_warming_cycle_checks(engine_instance, db_session, mock_evolution):
+    from heater.models.user import User
+    user = User(email="t2@t.com", hashed_password="pw")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    # Setup
+    me = Instance(
+        name="me_warm",
+        phone_number="111111",
+        user_id=user.id,
+        status="connected",
+        warming_enabled=True,
+        daily_limit=10,
+        messages_today=0,
+        schedule_start="00:00",
+        schedule_end="23:59"
+    )
+    peer = Instance(name="peer", phone_number="222222", user_id=user.id, status="connected", warming_enabled=True)
+    db_session.add_all([me, peer])
+    await db_session.commit()
+
+    # Mock random to choose private_message (index 0 usually for private_message if weights favor it, but here we force it)
+    # The code does: random.choices(["private_message", "reaction"], weights=[0.8, 0.2])[0]
+    # We need to patch random.choices to return ["private_message"]
+    # BUT random.choices is also used in _select_peer.
+    # _select_peer is called first, then activity selection.
+
+    with patch("random.choices", side_effect=[[peer], ["private_message"]]):
+        # Mock ContentGenerator
+        with patch("heater.warming.engine.ContentGenerator.casual_message", return_value="Hello"):
+            # Mock HumanBehavior typing delay
+            with patch("heater.warming.engine.HumanBehavior.typing_delay", new_callable=AsyncMock) as mock_delay:
+                mock_delay.return_value = 0.001
+
+                await engine_instance.run_warming_cycle(me.id)
+
+    # Verify evolution called
+    mock_evolution.send_text.assert_called()
+
+    # Verify stats updated
+    await db_session.refresh(me)
+    assert me.messages_today == 1
+    assert me.messages_total == 1
+    assert me.last_active_at is not None
+
+@pytest.mark.asyncio
+async def test_run_warming_cycle_limit_reached(engine_instance, db_session, mock_evolution):
+    from heater.models.user import User
+    user = User(email="t3@t.com", hashed_password="pw")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    me = Instance(
+        name="me_limit",
+        phone_number="111111",
+        user_id=user.id,
+        status="connected",
+        warming_enabled=True,
+        daily_limit=10,
+        messages_today=10, # Limit reached
+        schedule_start="00:00",
+        schedule_end="23:59"
+    )
+    db_session.add(me)
+    await db_session.commit()
+
+    await engine_instance.run_warming_cycle(me.id)
+
+    mock_evolution.send_text.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_send_reaction(engine_instance, db_session, mock_evolution):
+    from heater.models.user import User
+    user = User(email="t4@t.com", hashed_password="pw")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    me = Instance(name="me_react", phone_number="111111", user_id=user.id)
+    peer = Instance(name="peer_react", phone_number="222222", user_id=user.id)
+    db_session.add_all([me, peer])
+    await db_session.commit()
+
+    # Create a message to react to
+    msg = Message(
+        instance_id=peer.id,
+        peer_number=me.phone_number,
+        content="Hello",
+        external_id="MSG_FROM_PEER",
+        created_at=datetime.utcnow()
+    )
+    db_session.add(msg)
+    await db_session.commit()
+
+    await engine_instance.send_reaction(me, peer)
+
+    mock_evolution.send_reaction.assert_called_once()
+    args = mock_evolution.send_reaction.call_args[0]
+    assert args[0] == "me_react"
+    assert args[1]["id"] == "MSG_FROM_PEER"
+    # verify DB log
+    result = await db_session.execute(select(Message).where(Message.message_type == "reaction"))
+    reaction_msg = result.scalars().first()
+    assert reaction_msg is not None
+    assert reaction_msg.instance_id == me.id


### PR DESCRIPTION
Added a comprehensive unit test suite for the Chip Heater backend using `pytest`.
The tests cover:
- API endpoints (instances, warming control, webhooks, authentication)
- Warming engine logic (peer selection, message generation, scheduling)
- Error handling (Evolution API failures, invalid requests)
- Database integration using in-memory SQLite

Also improved error handling in the webhook endpoint to gracefully handle invalid JSON payloads.
Configured `conftest.py` with fixtures for database session, mocked Evolution client, and authenticated client.

---
*PR created automatically by Jules for task [8932773117251467960](https://jules.google.com/task/8932773117251467960) started by @mhprol*